### PR TITLE
CADP-17144 - Add CKA_ID sample support

### DIFF
--- a/pkcs11/C/pkcs11_sample_attributes.c
+++ b/pkcs11/C/pkcs11_sample_attributes.c
@@ -286,6 +286,7 @@ void usage()
     printf ("-a alias: key alias, an alias can be used as part of template during key creation. Looking up an existing key by means of an alias is not supported in this sample program.\n");
     printf ("-ct cached_time cached time for key in minutes\n");
     printf ("-ls lifespan: how many days until next version will be automatically rotated(created); template with lifespan will be versioned key automatically.");
+    printf ("-I Non-unique searchable ID (CKA_ID).");
     printf ("-z key_size key size for symmetric key in bytes.");
     printf ("-C ... clear alias\n");
     printf ("-D ... delete custom attributes (see below)\n");
@@ -330,6 +331,7 @@ int main(int argc, char *argv[])
     char        *pKsid = NULL;
     int         ksid_type = keyIdLabel;
     char        *keyAlias = NULL;
+    char        *idattr = NULL;
     CK_ULONG     modulusBufLen = 520;
     CK_ULONG     privExpoBufLen = 512;
     CK_ULONG     pubExpoBufLen = 32;
@@ -347,7 +349,7 @@ int main(int argc, char *argv[])
     CK_BYTE     modulusBuf[ASYMKEY_BUF_LEN];
     unsigned long lifespan = 1;
 
-    while ((c = newgetopt(argc, argv, "p:kp:m:s:i:a:z:d:g:v:1:2:3:4:5:ls:ct:CDZP")) != EOF)
+    while ((c = newgetopt(argc, argv, "p:kp:m:s:i:a:I:z:d:g:v:1:2:3:4:5:ls:ct:CDZP")) != EOF)
     {
         switch (c)
         {
@@ -357,9 +359,11 @@ int main(int argc, char *argv[])
         case 'p':
             pin = optarg;
             break;
+        case 'I':
+			idattr = optarg;
+            break;
         case 'k':
             keyLabel = optarg;
-            symmetric = 1;
             break;
         case 'P':
             symmetric = 0;
@@ -439,6 +443,11 @@ int main(int argc, char *argv[])
         pKsid = keyLabel;
         ksid_type = keyIdLabel;
     }
+	else if (idattr)
+	{
+        pKsid = idattr;
+        ksid_type = keyIdAttr;
+	}
 
     if (NULL == pin || !pKsid) usage();
 
@@ -480,7 +489,22 @@ int main(int argc, char *argv[])
         loggedIn = 1;
         printf("Successfully logged in. \n");
 
-        if (symmetric == 0)
+		if (ksid_type = keyIdAttr)
+		{
+			CK_ULONG numObjects = 1000;
+			CK_OBJECT_HANDLE phKeys[1000];
+			int i = 0;
+
+			rc = findKeysByIdAttr(pKsid, &numObjects, phKeys);
+			if (rc != CKR_OK) {
+				break;
+			}
+			for (i = 0; i < numObjects; i++) {
+				printf("\nAttributes for key number %d\n", i + 1);
+				getAttributesValue(phKeys[i], 0, NULL, NULL);
+			}
+		}
+		else if (symmetric == 0)
         {
             rc = findKey(pKsid, ksid_type, CKO_PRIVATE_KEY, &hPrivateKey);
 

--- a/pkcs11/C/pkcs11_sample_helper.c
+++ b/pkcs11/C/pkcs11_sample_helper.c
@@ -1419,7 +1419,7 @@ CK_RV getAttributesValue(CK_OBJECT_HANDLE hKey)
     char        custom[5][1024];
 
     CK_BBOOL    bCacheOnHost, bVersioned, blaSensitive, blnExtractable;
-    int         custom1Index = 17;
+    int         custom1Index = 11;
 
     CK_ULONG    ulCreationTime, ulDeactivateTime = 0;
     CK_ATTRIBUTE_PTR pKeyTemplate = NULL;
@@ -1433,20 +1433,20 @@ CK_RV getAttributesValue(CK_OBJECT_HANDLE hKey)
         {CKA_SERIAL_NUMBER, serialno, sizeof(serialno)},
         {CKA_CLASS, &keyCls, sizeof(keyCls) },                                    /*  3 */
 
-        {CKA_THALES_OBJECT_UUID, keyUuid, sizeof(keyUuid)},                       /*  8 */
+        {CKA_THALES_OBJECT_UUID, keyUuid, sizeof(keyUuid)},                       /*  4 */
         {CKA_THALES_OBJECT_MUID, keyMuid, sizeof(keyMuid)},
-        {CKA_THALES_OBJECT_ALIAS, keyAlias, sizeof(keyAlias)},                    /*  10 */
-        {CKA_THALES_OBJECT_IKID, keyImportedId, sizeof(keyImportedId)},           /* 11 */
-        {CKA_THALES_VERSIONED_KEY, &bVersioned, sizeof(bVersioned) },             /* 14 */
+        {CKA_THALES_OBJECT_ALIAS, keyAlias, sizeof(keyAlias)},                    /*  6 */
+        {CKA_THALES_OBJECT_IKID, keyImportedId, sizeof(keyImportedId)},           /* 7 */
+        {CKA_THALES_VERSIONED_KEY, &bVersioned, sizeof(bVersioned) },             /* 8 */
 
         {CKA_ALWAYS_SENSITIVE,	&blaSensitive,	sizeof(CK_BBOOL)	},
         {CKA_NEVER_EXTRACTABLE,	&blnExtractable,	sizeof(CK_BBOOL)	},
 
-        {CKA_THALES_CUSTOM_1, custom[0], sizeof(custom[0])},                          /* 17 */
+        {CKA_THALES_CUSTOM_1, custom[0], sizeof(custom[0])},                          /* 11 */
         {CKA_THALES_CUSTOM_2, custom[1], sizeof(custom[1])},
         {CKA_THALES_CUSTOM_3, custom[2], sizeof(custom[2])},
-        {CKA_THALES_CUSTOM_4, custom[3], sizeof(custom[3])},                          /* 20 */
-        {CKA_THALES_CUSTOM_5, custom[4], sizeof(custom[4])}		                      /* 21 */
+        {CKA_THALES_CUSTOM_4, custom[3], sizeof(custom[3])},                          /* 14 */
+        {CKA_THALES_CUSTOM_5, custom[4], sizeof(custom[4])}		                      /* 15 */
     };
     CK_ULONG getAttrsTemplateSize = sizeof(getAttrsTemplate)/sizeof(CK_ATTRIBUTE);
 
@@ -1484,18 +1484,17 @@ CK_RV getAttributesValue(CK_OBJECT_HANDLE hKey)
     printf("CKA_NEVER_EXTRACTABLE: \t%s\n", blnExtractable  ? "true" : "false");
     printf("CKA_ALWAYS_SENSITIVE:  \t%s\n", blaSensitive  ? "true" : "false");
 
-    printf("CKA_THALES_OBJECT_UUID:  '%.*s'\n", (int)pKeyTemplate[ 8].ulValueLen, keyUuid);
-    printf("CKA_THALES_OBJECT_MUID:  '%.*s'\n", (int)pKeyTemplate[ 9].ulValueLen, keyMuid);
-    printf("CKA_THALES_OBJECT_ALIAS: '%.*s'\n", (int)pKeyTemplate[10].ulValueLen, keyAlias);
-    printf("CKA_THALES_OBJECT_IKID:  '%.*s'\n", (int)pKeyTemplate[11].ulValueLen, keyImportedId);
+    printf("CKA_THALES_OBJECT_UUID:  '%.*s'\n", (int)pKeyTemplate[4].ulValueLen, keyUuid);
+    printf("CKA_THALES_OBJECT_MUID:  '%.*s'\n", (int)pKeyTemplate[5].ulValueLen, keyMuid);
+    printf("CKA_THALES_OBJECT_ALIAS: '%.*s'\n", (int)pKeyTemplate[6].ulValueLen, keyAlias);
+    printf("CKA_THALES_OBJECT_IKID:  '%.*s'\n", (int)pKeyTemplate[7].ulValueLen, keyImportedId);
 
-    for(i=0; i<5; i++)
+	for(i=0; i<5; i++)
     {
         custom[i][(int)pKeyTemplate[custom1Index+i].ulValueLen] = 0;
         printf("CKA_THALES_CUSTOM_%d: '%s' (length %d)\n", (int)i+1, custom[i], (int)pKeyTemplate[custom1Index+i].ulValueLen);
     }
 
- 
     if( pKeyTemplate )
     {
         free ( pKeyTemplate );

--- a/pkcs11/C/pkcs11_sample_helper.c
+++ b/pkcs11/C/pkcs11_sample_helper.c
@@ -292,7 +292,7 @@ CK_RV findKeyByVersion( char* keyLabel, CK_ULONG keyVersion, CK_OBJECT_HANDLE_PT
     {
         rc = FunctionListFuncPtr->C_FindObjects( hSession,
                 phKey,
-                MAX_FIND_RETURN,
+				MAX_FIND_RETURN,
                 &numOfObjReturned );
 
         if (rc != CKR_OK )
@@ -453,6 +453,9 @@ parse_ksid_sel(char *sel, char **ppKsid)
     case 'u':
         sid_type = keyIdUuid;
         break;
+    case 'i':
+        sid_type = keyIdAttr;
+        break;
     case 'm':
         sid_type = keyIdMuid;
         break;
@@ -536,6 +539,10 @@ CK_RV findKey( char* keySearchId, int keyidType, CK_OBJECT_CLASS keyType, CK_OBJ
         findKeyTemplatePass[0].type = CKA_LABEL;
         break;
 
+    case keyIdAttr:
+        findKeyTemplatePass[0].type = CKA_ID;
+        break;
+
     case keyIdUuid:
         findKeyTemplatePass[0].type = CKA_THALES_OBJECT_UUID;
         break;
@@ -599,6 +606,80 @@ CK_RV findKey( char* keySearchId, int keyidType, CK_OBJECT_CLASS keyType, CK_OBJ
 
         if ((numOfObjReturned == 0) || (numOfObjReturned == 1))
         {
+            break;
+        }
+    }
+
+    rc = FunctionListFuncPtr->C_FindObjectsFinal(hSession);
+
+    if (rc != CKR_OK)
+    {
+        fprintf (stderr, "FAIL: Call to C_FindObjectsFinal failed; rc=0x%08x.\n", (unsigned int)rc);
+    }
+
+    return rc;
+}
+
+
+CK_RV findKeysByIdAttr(char* keySearchId, CK_ULONG *numObjects, CK_OBJECT_HANDLE *phKeys)
+{
+    CK_RV rc = CKR_OK;
+    CK_UTF8CHAR  *ksid = (CK_UTF8CHAR *) keySearchId;
+    CK_ULONG ksid_len = keySearchId ? (CK_ULONG) strlen(keySearchId) : 0;
+
+    /* find the key by CKA_ID. */
+    CK_ULONG  numOfObjReturned = 0;
+    CK_ATTRIBUTE_PTR findKeyTemplatePtr;
+    CK_ULONG  findKeyTemplateSize;
+
+    /* find the key by CKA_LABEL. */
+    CK_ATTRIBUTE findKeyTemplatePass[] =
+    {
+        {CKA_ID, ksid, ksid_len}
+    };
+
+	findKeyTemplatePtr = findKeyTemplatePass;
+    findKeyTemplateSize = sizeof(findKeyTemplatePass)/sizeof(CK_ATTRIBUTE);
+
+    /* call FindObjectsFinal just in case there's another search ongoing for this session. */
+    rc = FunctionListFuncPtr->C_FindObjectsFinal(hSession);
+    if (rc != CKR_OK)
+    {
+        fprintf (stderr, "FAIL: call to the first C_FindObjectsFinal() failed; rc=0x%08x\n", (unsigned int)rc);
+        *phKeys = CK_INVALID_HANDLE;
+        return rc;
+    }
+
+    rc = FunctionListFuncPtr->C_FindObjectsInit(hSession,
+            findKeyTemplatePtr,
+            findKeyTemplateSize
+                                               );
+    if (rc != CKR_OK)
+    {
+        fprintf (stderr, "FAIL: call to C_FindObjectsInit() failed: rc=0x%08x.\n", (unsigned int)rc);
+        *phKeys = CK_INVALID_HANDLE;
+        return rc;
+    }
+
+    /* loop thorugh C_FindObjcts until numOfObjReturned is 0 and we break out
+     * of the loop. we expect to find only 1  key that matches the name.
+     */
+
+    while (CK_TRUE)
+    {
+        rc = FunctionListFuncPtr->C_FindObjects( hSession,
+                phKeys,
+                *numObjects,
+                &numOfObjReturned);
+
+        if (rc != CKR_OK )
+        {
+            fprintf (stderr, "Error: call to C_FindObjects() returned %d objects with error; rc=0x%08x.\n", (int)numOfObjReturned, (unsigned int)rc);
+        }
+
+        if ((numOfObjReturned == 0) || (numOfObjReturned <= *numObjects))
+        {
+			*numObjects = numOfObjReturned;
             break;
         }
     }
@@ -1308,6 +1389,113 @@ CK_RV getSymAttributesValue(CK_OBJECT_HANDLE hKey, CK_ULONG keyDateCount, CK_ATT
             printf("%s: year: %s, month: %s, day: %s.\n", pKeyDateDesc, ch_year, ch_mon, ch_mday);
     }
 
+    if( pKeyTemplate )
+    {
+        free ( pKeyTemplate );
+    }
+    return rc;
+}
+
+
+CK_RV getAttributesValue(CK_OBJECT_HANDLE hKey)
+{
+    CK_RV		rc = CKR_OK;
+    CK_DATE     createDate, endDate;
+    CK_BYTE     keyIdBuf[256];
+    char        keyLabel[256];
+    char        keyUuid[128];
+    char        keyMuid[128];
+    char        keyImportedId[128];
+    char        keyAlias[256];
+    CK_ULONG    ulCachedTime, i;
+    CK_ULONG    ulLifeSpan=0;
+    CK_OBJECT_CLASS	keyCls;
+    CK_LONG     lKeyVersion;
+    char        ch_year[5];
+    char        ch_mon[3];
+    char        ch_mday[3];
+
+    char        serialno[256]= {0};
+    char        custom[5][1024];
+
+    CK_BBOOL    bCacheOnHost, bVersioned, blaSensitive, blnExtractable;
+    int         custom1Index = 17;
+
+    CK_ULONG    ulCreationTime, ulDeactivateTime = 0;
+    CK_ATTRIBUTE_PTR pKeyTemplate = NULL;
+    CK_DATE     keyTransDates[KEY_TRANS_DATES_MAX];
+    char        *pKeyDateDesc = NULL;
+
+    CK_ATTRIBUTE getAttrsTemplate[] =
+    {
+        {CKA_ID, keyIdBuf, sizeof(keyIdBuf) },                                    /*  0 */
+        {CKA_LABEL, keyLabel, sizeof(keyLabel) },                                 /*  1 */
+        {CKA_SERIAL_NUMBER, serialno, sizeof(serialno)},
+        {CKA_CLASS, &keyCls, sizeof(keyCls) },                                    /*  3 */
+
+        {CKA_THALES_OBJECT_UUID, keyUuid, sizeof(keyUuid)},                       /*  8 */
+        {CKA_THALES_OBJECT_MUID, keyMuid, sizeof(keyMuid)},
+        {CKA_THALES_OBJECT_ALIAS, keyAlias, sizeof(keyAlias)},                    /*  10 */
+        {CKA_THALES_OBJECT_IKID, keyImportedId, sizeof(keyImportedId)},           /* 11 */
+        {CKA_THALES_VERSIONED_KEY, &bVersioned, sizeof(bVersioned) },             /* 14 */
+
+        {CKA_ALWAYS_SENSITIVE,	&blaSensitive,	sizeof(CK_BBOOL)	},
+        {CKA_NEVER_EXTRACTABLE,	&blnExtractable,	sizeof(CK_BBOOL)	},
+
+        {CKA_THALES_CUSTOM_1, custom[0], sizeof(custom[0])},                          /* 17 */
+        {CKA_THALES_CUSTOM_2, custom[1], sizeof(custom[1])},
+        {CKA_THALES_CUSTOM_3, custom[2], sizeof(custom[2])},
+        {CKA_THALES_CUSTOM_4, custom[3], sizeof(custom[3])},                          /* 20 */
+        {CKA_THALES_CUSTOM_5, custom[4], sizeof(custom[4])}		                      /* 21 */
+    };
+    CK_ULONG getAttrsTemplateSize = sizeof(getAttrsTemplate)/sizeof(CK_ATTRIBUTE);
+
+    pKeyTemplate = (CK_ATTRIBUTE_PTR)calloc( (getAttrsTemplateSize), sizeof(CK_ATTRIBUTE) );
+    if(!pKeyTemplate)
+    {
+        printf ("Error allocating memory for pKeyTemplate!\n");
+        return CKR_HOST_MEMORY;
+    }
+
+    for(i=0; i<getAttrsTemplateSize; i++)
+    {
+        pKeyTemplate[i].type = getAttrsTemplate[i].type;
+        pKeyTemplate[i].pValue = getAttrsTemplate[i].pValue;
+        pKeyTemplate[i].ulValueLen = getAttrsTemplate[i].ulValueLen;
+    }
+
+    rc = FunctionListFuncPtr->C_GetAttributeValue(hSession,
+            hKey,
+            pKeyTemplate,
+            getAttrsTemplateSize);
+
+    if (rc != CKR_OK)
+    {
+        printf ("Error getting key attributes: %08x.\n", (unsigned int)rc);
+        return rc;
+    }
+
+    printf("CKA_ID: '%.*s'\n", (int)pKeyTemplate[0].ulValueLen, keyIdBuf);
+    printf("CKA_LABEL: '%.*s'\n", (int)pKeyTemplate[1].ulValueLen, keyLabel);
+    printf("CKA_CLASS: %08x\n", (unsigned int)keyCls);
+
+    printf("CKA_THALES_VERSIONED_KEY:  %s\n", bVersioned  ? "true" : "false");
+
+    printf("CKA_NEVER_EXTRACTABLE: \t%s\n", blnExtractable  ? "true" : "false");
+    printf("CKA_ALWAYS_SENSITIVE:  \t%s\n", blaSensitive  ? "true" : "false");
+
+    printf("CKA_THALES_OBJECT_UUID:  '%.*s'\n", (int)pKeyTemplate[ 8].ulValueLen, keyUuid);
+    printf("CKA_THALES_OBJECT_MUID:  '%.*s'\n", (int)pKeyTemplate[ 9].ulValueLen, keyMuid);
+    printf("CKA_THALES_OBJECT_ALIAS: '%.*s'\n", (int)pKeyTemplate[10].ulValueLen, keyAlias);
+    printf("CKA_THALES_OBJECT_IKID:  '%.*s'\n", (int)pKeyTemplate[11].ulValueLen, keyImportedId);
+
+    for(i=0; i<5; i++)
+    {
+        custom[i][(int)pKeyTemplate[custom1Index+i].ulValueLen] = 0;
+        printf("CKA_THALES_CUSTOM_%d: '%s' (length %d)\n", (int)i+1, custom[i], (int)pKeyTemplate[custom1Index+i].ulValueLen);
+    }
+
+ 
     if( pKeyTemplate )
     {
         free ( pKeyTemplate );

--- a/pkcs11/C/pkcs11_sample_helper.h
+++ b/pkcs11/C/pkcs11_sample_helper.h
@@ -237,6 +237,7 @@ extern unsigned long ulCachedTime;
 #define 	keyIdMuid   0x0011
 #define 	keyIdImport 0x0100
 #define     keyIdAlias  0x0101
+#define	    keyIdAttr   0x0111
 
 
 int newgetopt(int argc, char* const *argv, const char *optstr);


### PR DESCRIPTION
- Added functionality for pkcs11_sample_create_object to create keys with a CKA_ID attribute
- Added functionality for pkcs11_sample_attributes to find one or more objects with a given CKA_ID
- Added functionality for pkcs11_sample_attributes to use C_GetAttributeValue for CKA_ID given object handle