### PR TITLE
[CADP-17144] Add CKA_ID sample support

### DIFF
--- a/pkcs11/C/pkcs11_sample_attributes.c
+++ b/pkcs11/C/pkcs11_sample_attributes.c
@@ -302,6 +302,7 @@ void usage()
     printf ("-a alias: key alias, an alias can be used as part of template during key creation. Looking up an existing key by means of an alias is not supported in this sample program.\n");
     printf ("-ct cached_time cached time for key in minutes\n");
     printf ("-ls lifespan: how many days until next version will be automatically rotated(created); template with lifespan will be versioned key automatically.\n");
+    printf ("-I Non-unique searchable ID (CKA_ID).");
     printf ("-z key_size key size for symmetric key in bytes.\n");
     printf ("-c curve oid: for ECC keys only.\n");
     printf ("-C ... clear alias\n");
@@ -348,6 +349,7 @@ int main(int argc, char *argv[])
     char        *pKsid = NULL;
     int         ksid_type = keyIdLabel;
     char        *keyAlias = NULL;
+    char        *idattr = NULL;
     CK_ULONG     modulusBufLen = 520;
     CK_ULONG     privExpoBufLen = 512;
     CK_ULONG     pubExpoBufLen = 32;
@@ -365,7 +367,7 @@ int main(int argc, char *argv[])
     CK_BYTE     modulusBuf[ASYMKEY_BUF_LEN];
     unsigned long lifespan = 1;
 
-    while ((c = newgetopt(argc, argv, "c:p:kp:m:s:i:a:z:d:g:v:1:2:3:4:5:ls:ct:CDZP")) != EOF)
+    while ((c = newgetopt(argc, argv, "c:p:kp:m:s:i:a:I:z:d:g:v:1:2:3:4:5:ls:ct:CDZP")) != EOF)
     {
         switch (c)
         {
@@ -378,9 +380,11 @@ int main(int argc, char *argv[])
         case 'p':
             pin = optarg;
             break;
+        case 'I':
+			idattr = optarg;
+            break;
         case 'k':
             keyLabel = optarg;
-            symmetric = 1;
             break;
         case 'P':
             symmetric = 0;
@@ -460,6 +464,11 @@ int main(int argc, char *argv[])
         pKsid = keyLabel;
         ksid_type = keyIdLabel;
     }
+	else if (idattr)
+	{
+        pKsid = idattr;
+        ksid_type = keyIdAttr;
+	}
 
     if (NULL == pin || !pKsid) usage();
 
@@ -501,7 +510,22 @@ int main(int argc, char *argv[])
         loggedIn = 1;
         printf("Successfully logged in. \n");
 
-        if (symmetric == 0)
+		if (ksid_type = keyIdAttr)
+		{
+			CK_ULONG numObjects = 1000;
+			CK_OBJECT_HANDLE phKeys[1000];
+			int i = 0;
+
+			rc = findKeysByIdAttr(pKsid, &numObjects, phKeys);
+			if (rc != CKR_OK) {
+				break;
+			}
+			for (i = 0; i < numObjects; i++) {
+				printf("\nAttributes for key number %d\n", i + 1);
+				getAttributesValue(phKeys[i], 0, NULL, NULL);
+			}
+		}
+		else if (symmetric == 0)
         {
             rc = findKey(pKsid, ksid_type, CKO_PRIVATE_KEY, &hPrivateKey);
 

--- a/pkcs11/C/pkcs11_sample_helper.c
+++ b/pkcs11/C/pkcs11_sample_helper.c
@@ -1426,7 +1426,7 @@ CK_RV getAttributesValue(CK_OBJECT_HANDLE hKey)
     char        custom[5][1024];
 
     CK_BBOOL    bCacheOnHost, bVersioned, blaSensitive, blnExtractable;
-    int         custom1Index = 17;
+    int         custom1Index = 11;
 
     CK_ULONG    ulCreationTime, ulDeactivateTime = 0;
     CK_ATTRIBUTE_PTR pKeyTemplate = NULL;
@@ -1440,20 +1440,20 @@ CK_RV getAttributesValue(CK_OBJECT_HANDLE hKey)
         {CKA_SERIAL_NUMBER, serialno, sizeof(serialno)},
         {CKA_CLASS, &keyCls, sizeof(keyCls) },                                    /*  3 */
 
-        {CKA_THALES_OBJECT_UUID, keyUuid, sizeof(keyUuid)},                       /*  8 */
+        {CKA_THALES_OBJECT_UUID, keyUuid, sizeof(keyUuid)},                       /*  4 */
         {CKA_THALES_OBJECT_MUID, keyMuid, sizeof(keyMuid)},
-        {CKA_THALES_OBJECT_ALIAS, keyAlias, sizeof(keyAlias)},                    /*  10 */
-        {CKA_THALES_OBJECT_IKID, keyImportedId, sizeof(keyImportedId)},           /* 11 */
-        {CKA_THALES_VERSIONED_KEY, &bVersioned, sizeof(bVersioned) },             /* 14 */
+        {CKA_THALES_OBJECT_ALIAS, keyAlias, sizeof(keyAlias)},                    /*  6 */
+        {CKA_THALES_OBJECT_IKID, keyImportedId, sizeof(keyImportedId)},           /* 7 */
+        {CKA_THALES_VERSIONED_KEY, &bVersioned, sizeof(bVersioned) },             /* 8 */
 
         {CKA_ALWAYS_SENSITIVE,	&blaSensitive,	sizeof(CK_BBOOL)	},
         {CKA_NEVER_EXTRACTABLE,	&blnExtractable,	sizeof(CK_BBOOL)	},
 
-        {CKA_THALES_CUSTOM_1, custom[0], sizeof(custom[0])},                          /* 17 */
+        {CKA_THALES_CUSTOM_1, custom[0], sizeof(custom[0])},                          /* 11 */
         {CKA_THALES_CUSTOM_2, custom[1], sizeof(custom[1])},
         {CKA_THALES_CUSTOM_3, custom[2], sizeof(custom[2])},
-        {CKA_THALES_CUSTOM_4, custom[3], sizeof(custom[3])},                          /* 20 */
-        {CKA_THALES_CUSTOM_5, custom[4], sizeof(custom[4])}		                      /* 21 */
+        {CKA_THALES_CUSTOM_4, custom[3], sizeof(custom[3])},                          /* 14 */
+        {CKA_THALES_CUSTOM_5, custom[4], sizeof(custom[4])}		                      /* 15 */
     };
     CK_ULONG getAttrsTemplateSize = sizeof(getAttrsTemplate)/sizeof(CK_ATTRIBUTE);
 
@@ -1491,18 +1491,17 @@ CK_RV getAttributesValue(CK_OBJECT_HANDLE hKey)
     printf("CKA_NEVER_EXTRACTABLE: \t%s\n", blnExtractable  ? "true" : "false");
     printf("CKA_ALWAYS_SENSITIVE:  \t%s\n", blaSensitive  ? "true" : "false");
 
-    printf("CKA_THALES_OBJECT_UUID:  '%.*s'\n", (int)pKeyTemplate[ 8].ulValueLen, keyUuid);
-    printf("CKA_THALES_OBJECT_MUID:  '%.*s'\n", (int)pKeyTemplate[ 9].ulValueLen, keyMuid);
-    printf("CKA_THALES_OBJECT_ALIAS: '%.*s'\n", (int)pKeyTemplate[10].ulValueLen, keyAlias);
-    printf("CKA_THALES_OBJECT_IKID:  '%.*s'\n", (int)pKeyTemplate[11].ulValueLen, keyImportedId);
+    printf("CKA_THALES_OBJECT_UUID:  '%.*s'\n", (int)pKeyTemplate[4].ulValueLen, keyUuid);
+    printf("CKA_THALES_OBJECT_MUID:  '%.*s'\n", (int)pKeyTemplate[5].ulValueLen, keyMuid);
+    printf("CKA_THALES_OBJECT_ALIAS: '%.*s'\n", (int)pKeyTemplate[6].ulValueLen, keyAlias);
+    printf("CKA_THALES_OBJECT_IKID:  '%.*s'\n", (int)pKeyTemplate[7].ulValueLen, keyImportedId);
 
-    for(i=0; i<5; i++)
+	for(i=0; i<5; i++)
     {
         custom[i][(int)pKeyTemplate[custom1Index+i].ulValueLen] = 0;
         printf("CKA_THALES_CUSTOM_%d: '%s' (length %d)\n", (int)i+1, custom[i], (int)pKeyTemplate[custom1Index+i].ulValueLen);
     }
 
- 
     if( pKeyTemplate )
     {
         free ( pKeyTemplate );

--- a/pkcs11/C/pkcs11_sample_helper.h
+++ b/pkcs11/C/pkcs11_sample_helper.h
@@ -238,6 +238,7 @@ extern unsigned long ulCachedTime;
 #define 	keyIdMuid   0x0011
 #define 	keyIdImport 0x0100
 #define     keyIdAlias  0x0101
+#define	    keyIdAttr   0x0111
 
 
 int newgetopt(int argc, char* const *argv, const char *optstr);


### PR DESCRIPTION
-     Added functionality for pkcs11_sample_create_object to create keys with a CKA_ID attribute
-     Added functionality for pkcs11_sample_attributes to find one or more objects with a given CKA_ID
-     Added functionality for pkcs11_sample_attributes to use C_GetAttributeValue for CKA_ID given object handle

